### PR TITLE
Allow local git connections as a workaround for not being able to connect

### DIFF
--- a/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
+++ b/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
@@ -515,7 +515,10 @@ public class GitSiteWagon extends AbstractWagon {
                 siteBranch = "gh-pages";
             }
 
-            url = "scm:git:ssh://" + url;
+            if (url.startsWith("file:///"))
+                url = "scm:git:" + url;
+            else
+                url = "scm:git:ssh://" + url;
             repository.setUrl(url);
         }
 


### PR DESCRIPTION
Allow local git connections as a workaround for not being able to connect securely on Windows.
