### PR TITLE
Support for wagon:upload goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,37 @@
 					<artifactId>plexus-maven-plugin</artifactId>
 					<version>1.3.8</version>
 				</plugin>
+				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											org.codehaus.plexus
+										</groupId>
+										<artifactId>
+											plexus-maven-plugin
+										</artifactId>
+										<versionRange>
+											[1.3.8,)
+										</versionRange>
+										<goals>
+											<goal>descriptor</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>

--- a/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
+++ b/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
@@ -529,7 +529,7 @@ public class GitSiteWagon extends AbstractWagon {
      * @see org.apache.maven.wagon.Wagon#put(java.io.File, java.lang.String)
      */
     public void put(File source, String destination) throws TransferFailedException {
-        throw new TransferFailedException("Not currently supported: put");
+    	putResource(source, destination);
     }
 
     /**
@@ -541,7 +541,11 @@ public class GitSiteWagon extends AbstractWagon {
             throw new IllegalArgumentException("Source is not a directory: " + sourceDirectory);
         }
 
-        Resource target = new Resource(destinationDirectory);
+        putResource(sourceDirectory, destinationDirectory);
+    }
+
+	private void putResource(File sourceDirectory, String destinationDirectory) throws TransferFailedException {
+		Resource target = new Resource(destinationDirectory);
 
         firePutInitiated(target, sourceDirectory);
 
@@ -601,7 +605,7 @@ public class GitSiteWagon extends AbstractWagon {
         }
 
         firePutCompleted(target, sourceDirectory);
-    }
+	}
 
     /**
      * Check that the ScmResult was a successful operation


### PR DESCRIPTION
This pull requests attempts to implement support for the maven-wagon-plugin:upload goal. I have done this by implementing the GitSiteWagon.put(source, destination) method so you can add something like the following to your POM:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
  <project
    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <modelVersion>4.0.0</modelVersion>
    <parent>
        <artifactId>m2e-android</artifactId>
        <groupId>me.gladwell.eclipse.m2e.android</groupId>
        <version>0.3.1-SNAPSHOT</version>
    </parent>
    <artifactId>me.gladwell.eclipse.m2e.android.update</artifactId>
    <packaging>eclipse-repository</packaging>
    <build>
        <extensions>
            <extension>
                <groupId>org.apache.maven.scm</groupId>
                <artifactId>maven-scm-provider-gitexe</artifactId>
                <version>1.3</version>
            </extension>
            <extension>
                <groupId>org.apache.maven.scm</groupId>
                <artifactId>maven-scm-manager-plexus</artifactId>
                <version>1.3</version>
            </extension>
            <extension>
                <groupId>org.kathrynhuxtable.maven.wagon</groupId>
                <artifactId>wagon-gitsite</artifactId>
                <version>0.4-SNAPSHOT</version>
            </extension>
        </extensions>
        <plugins>
            <plugin>
                <groupId>org.codehaus.mojo</groupId>
                <artifactId>wagon-maven-plugin</artifactId>
                <version>1.0-beta-3</version>
                <configuration>
                    <fromDir>${project.build.directory}/repository/</fromDir>
                    <url>gitsite:git@github.com/rgladwell/m2e-android.git/updates/master/m2e-android/</url>
                </configuration>
            </plugin>
        </plugins>
    </build>
  </project>
```

However, this is failing with the following error message:

`[ERROR] Failed to execute goal org.codehaus.mojo:wagon-maven-plugin:1.0-beta-3:upload (default-cli) on project me.gladwell.eclipse.m2e.android.update: Error handling resource: Error checking out: Unable to commit file. The git-pull command failed. Permission denied (publickey).`

Any ideas why the maven-wagon-plugin isn't prompting me for my github SSH key pass-phrase?
