### PR TITLE
Fixed the broken branch name support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.1</version>
+				<version>2.3.2</version>
 				<configuration>
 					<source>1.5</source>
 					<target>1.5</target>
@@ -84,7 +84,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.3</version>
+				<version>2.3.1</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -110,13 +110,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
 				<version>2.0</version>
-				<!-- <dependencies>
-					<dependency>
-						<groupId>org.apache.maven.scm</groupId>
-						<artifactId>maven-scm-provider-gitexe</artifactId>
-						<version>1.3</version>
-					</dependency>
-				</dependencies> -->
 				<configuration>
 					<goals>deploy</goals>
 					<mavenExecutorId>forked-path</mavenExecutorId>
@@ -125,21 +118,14 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-scm-plugin</artifactId>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.scm</groupId>
-						<artifactId>maven-scm-provider-gitexe</artifactId>
-						<version>1.3</version>
-					</dependency>
-				</dependencies>
+				<version>1.5</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>2.1</version>
+				<version>3.0</version>
 				<configuration>
 					<locales>en</locales>
-					<outputEncoding>${project.build.sourceEncoding}</outputEncoding>
 					<templateFile>${basedir}/src/site/site.vm</templateFile>
 				</configuration>
 			</plugin>
@@ -152,7 +138,7 @@
 			<plugin>
 				<groupId>com.agilejava.docbkx</groupId>
 				<artifactId>docbkx-maven-plugin</artifactId>
-				<version>2.0.10</version>
+				<version>2.0.13</version>
 				<executions>
 					<execution>
 						<goals>
@@ -226,17 +212,18 @@
 			<extension>
 				<groupId>org.apache.maven.scm</groupId>
 				<artifactId>maven-scm-provider-gitexe</artifactId>
-				<version>1.4</version>
+				<version>1.5</version>
 			</extension>
 			<extension>
 				<groupId>org.apache.maven.scm</groupId>
 				<artifactId>maven-scm-manager-plexus</artifactId>
-				<version>1.4</version>
+				<version>1.5</version>
 			</extension>
+			<!-- Can you really define yourself as an extension? -->
             <extension>
                 <groupId>org.kathrynhuxtable.maven.wagon</groupId>
                 <artifactId>wagon-gitsite</artifactId>
-                <version>0.3.1</version>
+                <version>${project.version}</version>
             </extension>
 		</extensions>
 	</build>
@@ -244,40 +231,40 @@
 		<dependency>
 			<groupId>org.apache.maven.scm</groupId>
 			<artifactId>maven-scm-api</artifactId>
-			<version>1.3</version>
+			<version>1.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.scm</groupId>
 			<artifactId>maven-scm-manager-plexus</artifactId>
-			<version>1.3</version>
+			<version>1.5</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.scm</groupId>
 			<artifactId>maven-scm-test</artifactId>
-			<version>1.3</version>
+			<version>1.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.scm</groupId>
 			<artifactId>maven-scm-provider-gitexe</artifactId>
-			<version>1.3</version>
+			<version>1.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.scm</groupId>
 			<artifactId>maven-scm-provider-git-commons</artifactId>
-			<version>1.3</version>
+			<version>1.5</version>
 		</dependency>
 		<!-- From wagon-providers -->
 		<dependency>
 			<groupId>org.apache.maven.wagon</groupId>
 			<artifactId>wagon-provider-api</artifactId>
-			<version>1.0-beta-6</version>
+			<version>1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.wagon</groupId>
 			<artifactId>wagon-provider-test</artifactId>
-			<version>1.0-beta-6</version>
+			<version>1.0</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- From wagon -->
@@ -293,22 +280,22 @@
 			<dependency>
 				<groupId>org.apache.maven.wagon</groupId>
 				<artifactId>wagon-provider-api</artifactId>
-				<version>1.0-beta-6</version>
+				<version>1.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven.wagon</groupId>
 				<artifactId>wagon-provider-test</artifactId>
-				<version>1.0-beta-6</version>
+				<version>1.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven.wagon</groupId>
 				<artifactId>wagon-ssh-common-test</artifactId>
-				<version>1.0-beta-6</version>
+				<version>1.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven.wagon</groupId>
 				<artifactId>wagon-ssh-common</artifactId>
-				<version>1.0-beta-6</version>
+				<version>1.0</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>
@@ -337,13 +324,13 @@
 			<dependency>
 				<groupId>org.codehaus.plexus</groupId>
 				<artifactId>plexus-container-default</artifactId>
-				<version>1.5.4</version>
+				<version>1.5.5</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.plexus</groupId>
 				<artifactId>plexus-utils</artifactId>
-				<version>1.5.8</version>
+				<version>3.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -398,7 +385,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jxr-plugin</artifactId>
-				<version>2.1</version>
+				<version>2.3</version>
 				<configuration>
 					<outputDirectory>${project.reporting.outputDirectory}/xref</outputDirectory>
 					<doctitle>${project.name} ${project.version} Code Cross-Reference</doctitle>
@@ -425,7 +412,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>2.4</version>
+				<version>2.5</version>
 				<configuration>
 					<targetJdk>1.5</targetJdk>
 				</configuration>
@@ -434,7 +421,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.6.1</version>
+				<version>2.8</version>
 				<configuration>
 					<notimestamp>true</notimestamp>
 					<archive>
@@ -467,7 +454,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.0</version>
+						<version>1.3</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -488,5 +475,6 @@
 	<properties>
 		<!-- Define the default encoding. We want this to be platform independent. -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.3.1</version>
+				<version>2.3.2</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -128,6 +128,15 @@
 					<locales>en</locales>
 					<templateFile>${basedir}/src/site/site.vm</templateFile>
 				</configuration>
+				<dependencies>
+				    <!-- Adding the gitsite wagon... -->
+				    <!-- See:  http://maven.apache.org/plugins/maven-site-plugin/examples/adding-deploy-protocol.html -->
+					<dependency>
+						<groupId>org.kathrynhuxtable.maven.wagon</groupId>
+						<artifactId>wagon-gitsite</artifactId>
+						<version>${project.version}</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<!--
 				Configure the docbkx plugin, which is a more fully featured DocBook converter than the one
@@ -208,24 +217,6 @@
 				</configuration>
 			</plugin>
 		</plugins>
-		<extensions>
-			<extension>
-				<groupId>org.apache.maven.scm</groupId>
-				<artifactId>maven-scm-provider-gitexe</artifactId>
-				<version>1.5</version>
-			</extension>
-			<extension>
-				<groupId>org.apache.maven.scm</groupId>
-				<artifactId>maven-scm-manager-plexus</artifactId>
-				<version>1.5</version>
-			</extension>
-			<!-- Can you really define yourself as an extension? -->
-            <extension>
-                <groupId>org.kathrynhuxtable.maven.wagon</groupId>
-                <artifactId>wagon-gitsite</artifactId>
-                <version>${project.version}</version>
-            </extension>
-		</extensions>
 	</build>
 	<dependencies>
 		<dependency>

--- a/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
+++ b/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
@@ -37,6 +37,7 @@ import org.apache.maven.scm.command.add.AddScmResult;
 import org.apache.maven.scm.command.checkin.CheckInScmResult;
 import org.apache.maven.scm.command.checkout.CheckOutScmResult;
 import org.apache.maven.scm.command.list.ListScmResult;
+import org.apache.maven.scm.log.ScmLogger;
 import org.apache.maven.scm.manager.NoSuchScmProviderException;
 import org.apache.maven.scm.manager.ScmManager;
 import org.apache.maven.scm.provider.ScmProvider;
@@ -370,8 +371,9 @@ public class GitSiteWagon extends AbstractWagon {
          *   scm:git:ssh://github.com/auser/project.git
          * to ensure a successful checkout, then adjust the relative path.
          */
-        String url = getRepository().getUrl();
+        String url = getRepository().getUrl() + targetName;
         String relPath = "";
+        
         if (!url.endsWith(".git")) {
             final int iGitSuffix = url.lastIndexOf(".git");
             if (iGitSuffix > 0) {
@@ -379,6 +381,9 @@ public class GitSiteWagon extends AbstractWagon {
                 url = url.substring(0, iGitSuffix + 4);
             }
         }
+        final ScmLogger logger = ((GitExeScmProvider)scmProvider).getLogger();
+        logger.debug("checkOut url: " + url);
+        logger.debug("checkOut relPath: " + relPath);
 
         // ok, we've established that target exists, or is empty.
         // Check the resource out; if it doesn't exist, that means we're in the svn repo url root,
@@ -411,6 +416,7 @@ public class GitSiteWagon extends AbstractWagon {
             String p = (String) stack.pop();
 
             relPath += p + '/';
+            logger.debug(" * checkOut relPath: " + relPath);
 
             File newDir = new File(checkoutDirectory, relPath);
 

--- a/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
+++ b/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
@@ -365,13 +365,17 @@ public class GitSiteWagon extends AbstractWagon {
             throw new TransferFailedException("Error listing repository: " + e.getMessage(), e);
         }
 
+        // URL didn't end with '/' on my maven-site 3.0 + Maven 3.0.4, so be defensive when combining url + targetName.
+        String url = getRepository().getUrl();
+        if (!url.endsWith("/")) url+="/";
+        url += targetName;
+
         /* A URL for a module will look like: 
          *   scm:git:ssh://github.com/auser/project.git/module
          * so we strip the module to get just:
          *   scm:git:ssh://github.com/auser/project.git
          * to ensure a successful checkout, then adjust the relative path.
          */
-        String url = getRepository().getUrl() + targetName;
         String relPath = "";
         
         if (!url.endsWith(".git")) {

--- a/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
+++ b/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
@@ -511,6 +511,9 @@ public class GitSiteWagon extends AbstractWagon {
             if (index > -1) {
                 siteBranch = url.substring(index + 1);
                 url        = url.substring(0, index);
+
+                // Maven seems to add '/' in the end even when I didn't specify it in POM
+                if (siteBranch.endsWith("/"))   siteBranch=siteBranch.substring(0,siteBranch.length()-1);
             } else {
                 siteBranch = "gh-pages";
             }


### PR DESCRIPTION
Maven appears to normalize the site URL by adding trailing '/' even when POM doesn't have it. This is observed in Maven site plugin 3.0 + Maven 3.0.4.

Since a branch name can never end with '/', the easiest way out here is to simply remove it if it's present.
