### PR TITLE
Fixed the broken branch name support.

### DIFF
--- a/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
+++ b/src/main/java/org/kathrynhuxtable/maven/wagon/gitsite/GitSiteWagon.java
@@ -511,6 +511,9 @@ public class GitSiteWagon extends AbstractWagon {
             if (index > -1) {
                 siteBranch = url.substring(index + 1);
                 url        = url.substring(0, index);
+
+                // Maven seems to add '/' in the end even when I didn't specify it in POM
+                if (siteBranch.endsWith("/"))   siteBranch=siteBranch.substring(0,siteBranch.length()-1);
             } else {
                 siteBranch = "gh-pages";
             }


### PR DESCRIPTION
Maven appears to normalize the site URL by adding trailing '/' even when POM doesn't have it. This is observed in Maven site plugin 3.0 + Maven 3.0.4.

Since a branch name can never end with '/', the easiest way out here is to simply remove it if it's present.
